### PR TITLE
Upgrade versions in the GH Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,12 +8,13 @@ on:
 jobs:
   build-deploy:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Install dependencies
-      run: sudo apt-get install -y pandoc
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
     - name: Build the website
       run: |
         ./build.sh

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+    - name: Install dependencies
+      run: sudo apt-get install -y pandoc
     - uses: actions/setup-python@v5
       with:
         python-version: '3.14'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.14'
     - name: Build the website
       run: |
         ./build.sh


### PR DESCRIPTION
Updated GitHub Actions workflow to use Ubuntu 24.04 and newer action versions.

This also brings the file close to https://github.com/ncsu-geoforall-lab/geospatial-simulations-course/blob/master/.github/workflows/gh-pages.yml